### PR TITLE
added aiohttp and interceptable request functions

### DIFF
--- a/examples/all_.py
+++ b/examples/all_.py
@@ -1,0 +1,31 @@
+from examples import (
+	day_details_example,
+	group_example,
+	market_map_example,
+	market_watch_example,
+	symbol_example
+)
+from asyncio import run
+
+if __name__ == '__main__':
+	print('*' * 50, 'day_details_example RunMode: Sync', '*' * 50)
+	day_details_example.method_sync()
+	print('*' * 50, 'group_example RunMode: Sync', '*' * 50)
+	group_example.method_sync()
+	print('*' * 50, 'market_map_example RunMode: Sync', '*' * 50)
+	market_map_example.method_sync()
+	print('*' * 50, 'market_watch_example RunMode: Sync', '*' * 50)
+	market_watch_example.method_sync()
+	print('*' * 50, 'symbol_example RunMode: Sync', '*' * 50)
+	symbol_example.method_sync()
+	
+	print('*' * 50, 'day_details_example RunMode: Async', '*' * 50)
+	run(day_details_example.method_async())
+	print('*' * 50, 'group_example RunMode: Async', '*' * 50)
+	run(group_example.method_async())
+	print('*' * 50, 'market_map_example RunMode: Async', '*' * 50)
+	run(market_map_example.method_async())
+	print('*' * 50, 'market_watch_example RunMode: Async', '*' * 50)
+	run(market_watch_example.method_async())
+	print('*' * 50, 'symbol_example RunMode: Async', '*' * 50)
+	run(symbol_example.method_async())

--- a/examples/day_details_example.py
+++ b/examples/day_details_example.py
@@ -2,29 +2,109 @@ from jdatetime import date as jdate
 
 from tsetmc_api.day_details import DayDetails
 
-# تغییرات نماد در یک روز
-day_details = DayDetails(symbol_id='14079693677610396', date=jdate(1402, 3, 1))
 
-# قیمت‌های نهایی
-price_overview = day_details.get_price_overview()
+def method_sync():
+	# تغییرات نماد در یک روز
+	day_details = DayDetails(symbol_id='14079693677610396', date=jdate(1402, 3, 1))
+	
+	# قیمت‌های نهایی
+	price_overview = day_details.get_price_overview()
+	print('price overview: \n\t', price_overview)
+	
+	# تغییرات قیمتی
+	price_data = day_details.get_price_data()
+	print(f'price data({len(price_data)}):\n', '\n'.join(f'\t {item}' for item in price_data[-5:]))
+	
+	# تغییرات صف‌های خرید و فروش
+	orderbook_data = day_details.get_orderbook_data()
+	print(f'orderbook data({len(orderbook_data)}):\n', '\n'.join(f'\t {item}' for item in orderbook_data[-5:]))
+	
+	# معاملات
+	trades_data = day_details.get_trades_data()
+	print(f'trades data({len(trades_data)}):\n', '\n'.join(f'\t {item}' for item in trades_data[-5:]))
+	
+	# بیشترین و کمترین قیمت روز
+	thresholds_data = day_details.get_thresholds_data()
+	print('thresholds data: \n\t', thresholds_data)
+	
+	# تغییرات سهامداران عمده
+	old_shareholders, new_shareholders = day_details.get_shareholders_data()
+	print(f'share holders old({len(old_shareholders)}):\n', '\n'.join(f'\t {item}' for item in old_shareholders[-5:]))
+	print(f'share holders new({len(new_shareholders)}):\n', '\n'.join(f'\t {item}' for item in new_shareholders[-5:]))
+	
+	if old_shareholders:
+		sh = old_shareholders[0]
+	elif new_shareholders:
+		sh = new_shareholders[0]
+	else:
+		print('no share holders')
+		return
+	
+	print('share holder details: ', sh.shareholder.name)
+	
+	# چارت یک سهامدار
+	sh_chart_data = sh.get_chart_data()
+	print(f'share holder chart data({len(sh_chart_data)}):\n', '\n'.join(f'\t {item}' for item in new_shareholders[-5:]))
+	
+	# سهام یک سهامدار عمده
+	sh_portfolio = sh.shareholder.get_portfolio_data()
+	print(f'share holder portfolio data({len(sh_portfolio)}):\n', '\n'.join(f'\t {item}' for item in sh_portfolio[-5:]))
 
-# تغییرات قیمتی
-price_data = day_details.get_price_data()
 
-# تغییرات صف‌های خرید و فروش
-orderbook_data = day_details.get_orderbook_data()
+async def method_async():
+	# تغییرات نماد در یک روز
+	day_details = DayDetails(symbol_id='14079693677610396', date=jdate(1402, 3, 1))
+	
+	# قیمت‌های نهایی
+	price_overview = await day_details.aio_get_price_overview()
+	print('price overview: \n\t', price_overview)
 
-# معاملات
-trades_data = day_details.get_trades_data()
+	# تغییرات قیمتی
+	price_data = await day_details.aio_get_price_data()
+	print(f'price data({len(price_data)}):\n', '\n'.join(f'\t {item}' for item in price_data[-5:]))
 
-# بیشترین و کمترین قیمت روز
-thresholds_data = day_details.get_thresholds_data()
+	# تغییرات صف‌های خرید و فروش
+	orderbook_data = await day_details.aio_get_orderbook_data()
+	print(f'orderbook data({len(orderbook_data)}):\n', '\n'.join(f'\t {item}' for item in orderbook_data[-5:]))
+	
+	# معاملات
+	trades_data = await day_details.aio_get_trades_data()
+	print(f'trades data({len(trades_data)}):\n', '\n'.join(f'\t {item}' for item in trades_data[-5:]))
+	
+	# بیشترین و کمترین قیمت روز
+	thresholds_data = await day_details.aio_get_thresholds_data()
+	print('thresholds data: \n\t', thresholds_data)
+	
+	# تغییرات سهامداران عمده
+	old_shareholders, new_shareholders = await day_details.aio_get_shareholders_data()
+	print(f'share holders old({len(old_shareholders)}):\n', '\n'.join(f'\t {item}' for item in old_shareholders[-5:]))
+	print(f'share holders new({len(new_shareholders)}):\n', '\n'.join(f'\t {item}' for item in new_shareholders[-5:]))
+	
+	if old_shareholders:
+		sh = old_shareholders[0]
+	elif new_shareholders:
+		sh = new_shareholders[0]
+	else:
+		print('no share holders')
+		return
+	
+	print('share holder details: ', sh.shareholder.name)
+	
+	# چارت یک سهامدار
+	sh_chart_data = await sh.aio_get_chart_data()
+	print(f'share holder chart data({len(sh_chart_data)}):\n', '\n'.join(f'\t {item}' for item in new_shareholders[-5:]))
+	
+	# سهام یک سهامدار عمده
+	sh_portfolio = await sh.shareholder.aio_get_portfolio_data()
+	print(f'share holder portfolio data({len(sh_portfolio)}):\n', '\n'.join(f'\t {item}' for item in sh_portfolio[-5:]))
 
-# تغییرات سهامداران عمده
-old_shareholders, new_shareholders = day_details.get_shareholders_data()
 
-# چارت یک سهامدار
-old_shareholders[0].get_chart_data()
-
-# سهام یک سهامدار عمده
-old_shareholders[0].shareholder.get_portfolio_data()
+if __name__ == '__main__':
+	print('RunMode: Sync')
+	method_sync()
+	
+	print('RunMode: Async')
+	
+	from asyncio import run
+	
+	run(method_async())

--- a/examples/group_example.py
+++ b/examples/group_example.py
@@ -1,4 +1,24 @@
 from tsetmc_api.group import Group
 
-# اطلاعات گروه‌ها
-all_groups = Group.get_all_groups()
+
+def method_sync():
+	# اطلاعات گروه‌ها
+	all_groups = Group.get_all_groups()
+	print(f'all groups({len(all_groups)}):\n', '\n'.join(f'\t {item}' for item in all_groups[-5:]))
+
+
+async def method_async():
+	# اطلاعات گروه‌ها
+	all_groups = await Group.aio_get_all_groups()
+	print(f'all groups({len(all_groups)}):\n', '\n'.join(f'\t {item}' for item in all_groups[-5:]))
+
+
+if __name__ == '__main__':
+	print('RunMode: Sync')
+	method_sync()
+	
+	print('RunMode: Async')
+	
+	from asyncio import run
+	
+	run(method_async())

--- a/examples/market_map_example.py
+++ b/examples/market_map_example.py
@@ -1,10 +1,38 @@
 from tsetmc_api.market_map import MarketMap, MapType
 
-# نقشه‌ی بازار
-market_map = MarketMap()
 
-# گرفتن نقشه‌ی بازار بر اساس ارزش
-map_by_value = market_map.get_market_map_data(map_type=MapType.MARKET_VALUE)
+def method_sync():
+	# نقشه‌ی بازار
+	market_map = MarketMap()
+	
+	# گرفتن نقشه‌ی بازار بر اساس ارزش
+	map_by_value = market_map.get_market_map_data(map_type=MapType.MARKET_VALUE)
+	print(f'map by value({len(map_by_value)}):\n', '\n'.join(f'\t {k}: {v}' for k, v in list(map_by_value.items())[-5:]))
 
-# گرفتن نقشه‌ی بازار بر اساس حجم
-map_by_volume = market_map.get_market_map_data(map_type=MapType.MARKET_VOLUME)
+	# گرفتن نقشه‌ی بازار بر اساس حجم
+	map_by_volume = market_map.get_market_map_data(map_type=MapType.MARKET_VOLUME)
+	print(f'map by volume({len(map_by_volume)}):\n', '\n'.join(f'\t {k}: {v}' for k, v in list(map_by_volume.items())[-5:]))
+
+
+async def method_async():
+	# نقشه‌ی بازار
+	market_map = MarketMap()
+	
+	# گرفتن نقشه‌ی بازار بر اساس ارزش
+	map_by_value = await market_map.aio_get_market_map_data(map_type=MapType.MARKET_VALUE)
+	print(f'map by value({len(map_by_value)}):\n', '\n'.join(f'\t {k}: {v}' for k, v in list(map_by_value.items())[-5:]))
+	
+	# گرفتن نقشه‌ی بازار بر اساس حجم
+	map_by_volume = await market_map.aio_get_market_map_data(map_type=MapType.MARKET_VOLUME)
+	print(f'map by volume({len(map_by_volume)}):\n', '\n'.join(f'\t {k}: {v}' for k, v in list(map_by_volume.items())[-5:]))
+
+
+if __name__ == '__main__':
+	print('RunMode: Sync')
+	method_sync()
+	
+	print('RunMode: Async')
+	
+	from asyncio import run
+	
+	run(method_async())

--- a/examples/market_watch_example.py
+++ b/examples/market_watch_example.py
@@ -1,21 +1,66 @@
 from tsetmc_api.market_watch import MarketWatch
 
-# دیده‌بان بازار
-# توجه کنید که این اطلاعات از صفحه‌ی دیده‌بان بازاره و مثلا سابقه‌ی اینجا با اون سابقه‌ای که توی صفحه
-# نماد می‌بینیم فرق داره. اونا توی پکیج symbol قرار دارند.
-market_watch = MarketWatch()
 
-# اطلاعات قیمتی
-price_data = market_watch.get_price_data()
+def method_sync():
+	# دیده‌بان بازار
+	# توجه کنید که این اطلاعات از صفحه‌ی دیده‌بان بازاره و مثلا سابقه‌ی اینجا با اون سابقه‌ای که توی صفحه
+	# نماد می‌بینیم فرق داره. اونا توی پکیج symbol قرار دارند.
+	market_watch = MarketWatch()
+	
+	# اطلاعات قیمتی
+	price_data = market_watch.get_price_data()
+	print(f'price data({len(price_data)}):\n', '\n'.join(f'\t {k}: {v}' for k, v in list(price_data.items())[-5:]))
 
-# اطلاعات آماری به صورت خام
-raw_stats_data = market_watch.get_raw_stats_data()
+	# اطلاعات آماری به صورت خام
+	raw_stats_data = market_watch.get_raw_stats_data()
+	print(f'raw stats data({len(raw_stats_data)}):\n', '\n'.join(f'\t {k}: {v}' for k, v in list(raw_stats_data.items())[-5:]))
 
-# اطلاعات آماری به صورت parse شده
-stats_data = market_watch.get_stats_data()
+	# اطلاعات آماری به صورت parse شده
+	stats_data = market_watch.get_stats_data()
+	print(f'stats data({len(stats_data)}):\n', '\n'.join(f'\t {k}: {v}' for k, v in list(stats_data.items())[-5:]))
 
-# اطلاعات حقیقی حقوقی
-traders_type_data = market_watch.get_traders_type_data()
+	# اطلاعات حقیقی حقوقی
+	traders_type_data = market_watch.get_traders_type_data()
+	print(f'traders type data({len(traders_type_data)}):\n', '\n'.join(f'\t {k}: {v}' for k, v in list(traders_type_data.items())[-5:]))
 
-# اطلاعات سابقه
-daily_history_data = market_watch.get_daily_history_data()
+	# اطلاعات سابقه
+	daily_history_data = market_watch.get_daily_history_data()
+	print(f'daily history data({len(daily_history_data)}):\n', '\n'.join(f'\t {k}: {v}' for k, v in list(daily_history_data.items())[-5:]))
+
+
+async def method_async():
+	# دیده‌بان بازار
+	# توجه کنید که این اطلاعات از صفحه‌ی دیده‌بان بازاره و مثلا سابقه‌ی اینجا با اون سابقه‌ای که توی صفحه
+	# نماد می‌بینیم فرق داره. اونا توی پکیج symbol قرار دارند.
+	market_watch = MarketWatch()
+	
+	# اطلاعات قیمتی
+	price_data = await market_watch.aio_get_price_data()
+	print(f'price data({len(price_data)}):\n', '\n'.join(f'\t {k}: {v}' for k, v in list(price_data.items())[-5:]))
+	
+	# اطلاعات آماری به صورت خام
+	raw_stats_data = await market_watch.aio_get_raw_stats_data()
+	print(f'raw stats data({len(raw_stats_data)}):\n', '\n'.join(f'\t {k}: {v}' for k, v in list(raw_stats_data.items())[-5:]))
+	
+	# اطلاعات آماری به صورت parse شده
+	stats_data = await market_watch.aio_get_stats_data()
+	print(f'stats data({len(stats_data)}):\n', '\n'.join(f'\t {k}: {v}' for k, v in list(stats_data.items())[-5:]))
+	
+	# اطلاعات حقیقی حقوقی
+	traders_type_data = await market_watch.aio_get_traders_type_data()
+	print(f'traders type data({len(traders_type_data)}):\n', '\n'.join(f'\t {k}: {v}' for k, v in list(traders_type_data.items())[-5:]))
+	
+	# اطلاعات سابقه
+	daily_history_data = await market_watch.aio_get_daily_history_data()
+	print(f'daily history data({len(daily_history_data)}):\n', '\n'.join(f'\t {k}: {v}' for k, v in list(daily_history_data.items())[-5:]))
+
+
+if __name__ == '__main__':
+	print('RunMode: Sync')
+	method_sync()
+	
+	print('RunMode: Async')
+	
+	from asyncio import run
+	
+	run(method_async())

--- a/examples/symbol_example.py
+++ b/examples/symbol_example.py
@@ -1,40 +1,130 @@
 from tsetmc_api.symbol import Symbol
 
-# دیدن مشخصات یک نماد (نماد آسیاتک)
-# این عددی که به عنوان symbol_id بهش میدیم، از تیکه‌ی آخر url صفحه‌ی آسیاتک توی سایت برداشته شده
-# مثلا آدرس آسیاتک توی tsetmc اینه: http://main.tsetmc.com/InstInfo/14079693677610396
-# اون تیکه آخرش میشه symbol_id
-symbol = Symbol(symbol_id='14079693677610396')
 
-# اطلاعات قیمتی داخل در یک نگاه
-price_overview = symbol.get_price_overview()
+def method_sync():
+	# دیدن مشخصات یک نماد (نماد آسیاتک)
+	# این عددی که به عنوان symbol_id بهش میدیم، از تیکه‌ی آخر url صفحه‌ی آسیاتک توی سایت برداشته شده
+	# مثلا آدرس آسیاتک توی tsetmc اینه: http://main.tsetmc.com/InstInfo/14079693677610396
+	# اون تیکه آخرش میشه symbol_id
+	symbol = Symbol(symbol_id='14079693677610396')
+	
+	# اطلاعات قیمتی داخل در یک نگاه
+	price_overview = symbol.get_price_overview()
+	print(f'price overview: \n\t', price_overview)
 
-# چارت داخل در یک نگاه
-intraday_price_chart_data = symbol.get_intraday_price_chart_data()
+	# چارت داخل در یک نگاه
+	intraday_price_chart_data = symbol.get_intraday_price_chart_data()
+	print(f'interaday price chart data({len(intraday_price_chart_data)}):\n', '\n'.join(f'\t {item}' for item in intraday_price_chart_data[-5:]))
 
-# پیام ناظر
-supervisor_message_data = symbol.get_supervisor_messages_data()
+	# پیام ناظر
+	supervisor_message_data = symbol.get_supervisor_messages_data()
+	print(f'supervisor message data({len(supervisor_message_data)}):\n', '\n'.join(f'\t {item}' for item in supervisor_message_data[-5:]))
 
-# اطلاعیه
-notification_data = symbol.get_notifications_data()
+	# اطلاعیه
+	notification_data = symbol.get_notifications_data()
+	print(f'notification data({len(notification_data)}):\n', '\n'.join(f'\t {item}' for item in notification_data[-5:]))
 
-# تغییر وضعیت
-state_changes_data = symbol.get_state_changes_data()
+	# تغییر وضعیت
+	state_changes_data = symbol.get_state_changes_data()
+	print(f'state changes data({len(state_changes_data)}):\n', '\n'.join(f'\t {item}' for item in state_changes_data[-5:]))
 
-# سابقه
-daily_history = symbol.get_daily_history()
+	# سابقه
+	daily_history = symbol.get_daily_history()
+	print(f'daily history data({len(daily_history)}):\n', '\n'.join(f'\t {item}' for item in daily_history[-5:]))
 
-# شناسه
-id_details = symbol.get_id_details()
+	# شناسه
+	id_details = symbol.get_id_details()
+	print(f'id details: \n\t', id_details)
 
-# حقیقی حقوقی
-traders_type_history = symbol.get_traders_type_history()
+	# حقیقی حقوقی
+	traders_type_history = symbol.get_traders_type_history()
+	print(f'traders type history({len(traders_type_history)}):\n', '\n'.join(f'\t {item}' for item in traders_type_history[-5:]))
 
-# سهامداران
-shareholders = symbol.get_shareholders_data()
+	# سهامداران
+	shareholders = symbol.get_shareholders_data()
+	print(f'share holders({len(shareholders)}):\n', '\n'.join(f'\t {item}' for item in shareholders[-5:]))
+	
+	if shareholders:
+		sh = shareholders[0]
+		print(f'shareholder info: {sh.shareholder.name}')
+	else:
+		print('no shareholders found')
+		return
+	
+	# چارتی که وقتی روی یک سهامدار کلیک میکنیم میده
+	shareholder_chart_data = sh.get_chart_data()
+	print(f'share holder chart data({len(shareholder_chart_data)}):\n', '\n'.join(f'\t {item}' for item in shareholder_chart_data[-5:]))
 
-# چارتی که وقتی روی یک سهامدار کلیک میکنیم میده
-shareholder_chart_data = shareholders[0].get_chart_data()
+	# سایر سهام سهامدار عمده
+	shareholder_portfolio_data = shareholders[0].shareholder.get_portfolio_data()
+	print(f'share holder portfolio data({len(shareholder_portfolio_data)}):\n', '\n'.join(f'\t {item}' for item in shareholder_portfolio_data[-5:]))
 
-# سایر سهام سهامدار عمده
-shareholder_portfolio_data = shareholders[0].shareholder.get_portfolio_data()
+
+async def method_async():
+	# دیدن مشخصات یک نماد (نماد آسیاتک)
+	# این عددی که به عنوان symbol_id بهش میدیم، از تیکه‌ی آخر url صفحه‌ی آسیاتک توی سایت برداشته شده
+	# مثلا آدرس آسیاتک توی tsetmc اینه: http://main.tsetmc.com/InstInfo/14079693677610396
+	# اون تیکه آخرش میشه symbol_id
+	symbol = Symbol(symbol_id='14079693677610396')
+	
+	# اطلاعات قیمتی داخل در یک نگاه
+	price_overview = await symbol.aio_get_price_overview()
+	print(f'price overview: \n\t', price_overview)
+
+	# چارت داخل در یک نگاه
+	intraday_price_chart_data = await symbol.aio_get_intraday_price_chart_data()
+	print(f'interaday price chart data({len(intraday_price_chart_data)}):\n', '\n'.join(f'\t {item}' for item in intraday_price_chart_data[-5:]))
+
+	# پیام ناظر
+	supervisor_message_data = await symbol.aio_get_supervisor_messages_data()
+	print(f'supervisor message data({len(supervisor_message_data)}):\n', '\n'.join(f'\t {item}' for item in supervisor_message_data[-5:]))
+
+	# اطلاعیه
+	notification_data = await symbol.aio_get_notifications_data()
+	print(f'notification data({len(notification_data)}):\n', '\n'.join(f'\t {item}' for item in notification_data[-5:]))
+
+	# تغییر وضعیت
+	state_changes_data = await symbol.aio_get_state_changes_data()
+	print(f'state changes data({len(state_changes_data)}):\n', '\n'.join(f'\t {item}' for item in state_changes_data[-5:]))
+
+	# سابقه
+	daily_history = await symbol.aio_get_daily_history()
+	print(f'daily history data({len(daily_history)}):\n', '\n'.join(f'\t {item}' for item in daily_history[-5:]))
+
+	# شناسه
+	id_details = await symbol.aio_get_id_details()
+	print(f'id details: \n\t', id_details)
+
+	# حقیقی حقوقی
+	traders_type_history = await symbol.aio_get_traders_type_history()
+	print(f'traders type history({len(traders_type_history)}):\n', '\n'.join(f'\t {item}' for item in traders_type_history[-5:]))
+	
+	# سهامداران
+	shareholders = await symbol.aio_get_shareholders_data()
+	print(f'share holders({len(shareholders)}):\n', '\n'.join(f'\t {item}' for item in shareholders[-5:]))
+	
+	if shareholders:
+		sh = shareholders[0]
+		print(f'shareholder info: {sh.shareholder.name}')
+	else:
+		print('no shareholders found')
+		return
+
+	# چارتی که وقتی روی یک سهامدار کلیک میکنیم میده
+	shareholder_chart_data = await sh.aio_get_chart_data()
+	print(f'share holder chart data({len(shareholder_chart_data)}):\n', '\n'.join(f'\t {item}' for item in shareholder_chart_data[-5:]))
+
+	# سایر سهام سهامدار عمده
+	shareholder_portfolio_data = await sh.shareholder.aio_get_portfolio_data()
+	print(f'share holder portfolio data({len(shareholder_portfolio_data)}):\n', '\n'.join(f'\t {item}' for item in shareholder_portfolio_data[-5:]))
+
+
+if __name__ == '__main__':
+	print('RunMode: Sync')
+	method_sync()
+	
+	print('RunMode: Async')
+	
+	from asyncio import run
+
+	run(method_async())

--- a/lib/tsetmc_api/day_details/_core.py
+++ b/lib/tsetmc_api/day_details/_core.py
@@ -1,25 +1,24 @@
 from collections import defaultdict
 from copy import deepcopy
 
-import requests
 from jdatetime import date as jdate
 
-from ..utils import convert_deven_to_jdate, convert_heven_to_jtime
+from ..utils import convert_deven_to_jdate, convert_heven_to_jtime, safe_request, aio_safe_request
 
 
-def get_day_details_price_overview(symbol_id: str, date: jdate) -> dict:
-    t = date.togregorian().strftime('%Y%m%d')
-    response = requests.get(
-        url=f'http://cdn.tsetmc.com/api/ClosingPrice/GetClosingPriceDaily/{symbol_id}/{t}',
-        params={},
-        headers={
-            'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36',
-        },
-        verify=False,
-        timeout=20,
-    )
-    response.raise_for_status()
-    response = response.json()['closingPriceDaily']
+def get_day_details_price_overview(symbol_id: str, date: jdate, response: dict = None) -> dict:
+    if response is None:
+        t = date.togregorian().strftime('%Y%m%d')
+        response = safe_request(
+            method='GET',
+            url=f'http://cdn.tsetmc.com/api/ClosingPrice/GetClosingPriceDaily/{symbol_id}/{t}',
+            params={},
+            headers={
+                'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36',
+            },
+            verify=False
+        )
+        response = response.json()['closingPriceDaily']
 
     return {
         "price_change": response["priceChange"],
@@ -35,19 +34,19 @@ def get_day_details_price_overview(symbol_id: str, date: jdate) -> dict:
     }
 
 
-def get_day_details_price_data(symbol_id: str, date: jdate) -> list[dict]:
-    t = date.togregorian().strftime('%Y%m%d')
-    response = requests.get(
-        url=f'http://cdn.tsetmc.com/api/ClosingPrice/GetClosingPriceHistory/{symbol_id}/{t}',
-        params={},
-        headers={
-            'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36',
-        },
-        verify=False,
-        timeout=20,
-    )
-    response.raise_for_status()
-    response = response.json()['closingPriceHistory']
+def get_day_details_price_data(symbol_id: str, date: jdate, response: dict = None) -> list[dict]:
+    if response is None:
+        t = date.togregorian().strftime('%Y%m%d')
+        response = safe_request(
+            method='GET',
+            url=f'http://cdn.tsetmc.com/api/ClosingPrice/GetClosingPriceHistory/{symbol_id}/{t}',
+            params={},
+            headers={
+                'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36',
+            },
+            verify=False
+        )
+        response = response.json()['closingPriceHistory']
 
     price_data = [{
         'time': convert_heven_to_jtime(heven=row['hEven']),
@@ -61,19 +60,19 @@ def get_day_details_price_data(symbol_id: str, date: jdate) -> list[dict]:
     return price_data
 
 
-def get_day_details_orderbook_data(symbol_id: str, date: jdate) -> list[dict]:
-    t = date.togregorian().strftime('%Y%m%d')
-    response = requests.get(
-        url=f'http://cdn.tsetmc.com/api/BestLimits/{symbol_id}/{t}',
-        params={},
-        headers={
-            'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36',
-        },
-        verify=False,
-        timeout=20,
-    )
-    response.raise_for_status()
-    response = response.json()['bestLimitsHistory']
+def get_day_details_orderbook_data(symbol_id: str, date: jdate, response: dict = None) -> list[dict]:
+    if response is None:
+        t = date.togregorian().strftime('%Y%m%d')
+        response = safe_request(
+            method='GET',
+            url=f'http://cdn.tsetmc.com/api/BestLimits/{symbol_id}/{t}',
+            params={},
+            headers={
+                'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36',
+            },
+            verify=False
+        )
+        response = response.json()['bestLimitsHistory']
     response = sorted(response, key=lambda x: (x['hEven'], x['number']))
 
     prev_data = {'buy_rows': [], 'sell_rows': []}
@@ -117,20 +116,20 @@ def get_day_details_orderbook_data(symbol_id: str, date: jdate) -> list[dict]:
     } for key, value in heven_map.items()]
 
 
-def get_day_details_trade_data(symbol_id: str, date: jdate, summarize: bool) -> list[dict]:
-    t = date.togregorian().strftime('%Y%m%d')
-    summarize_url_ph = 'true' if summarize else 'false'
-    response = requests.get(
-        url=f'http://cdn.tsetmc.com/api/Trade/GetTradeHistory/{symbol_id}/{t}/{summarize_url_ph}',
-        params={},
-        headers={
-            'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36',
-        },
-        verify=False,
-        timeout=20,
-    )
-    response.raise_for_status()
-    response = response.json()['tradeHistory']
+def get_day_details_trade_data(symbol_id: str, date: jdate, summarize: bool, response: dict = None) -> list[dict]:
+    if response is None:
+        t = date.togregorian().strftime('%Y%m%d')
+        summarize_url_ph = 'true' if summarize else 'false'
+        response = safe_request(
+            method='GET',
+            url=f'http://cdn.tsetmc.com/api/Trade/GetTradeHistory/{symbol_id}/{t}/{summarize_url_ph}',
+            params={},
+            headers={
+                'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36',
+            },
+            verify=False
+        )
+        response = response.json()['tradeHistory']
 
     return [{
         'time': convert_heven_to_jtime(heven=row['hEven']),
@@ -139,19 +138,19 @@ def get_day_details_trade_data(symbol_id: str, date: jdate, summarize: bool) -> 
     } for row in response]
 
 
-def get_day_details_traders_type_data(symbol_id: str, date: jdate) -> dict:
-    t = date.togregorian().strftime('%Y%m%d')
-    response = requests.get(
-        url=f'http://cdn.tsetmc.com/api/ClientType/GetClientTypeHistory/{symbol_id}/{t}',
-        params={},
-        headers={
-            'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36',
-        },
-        verify=False,
-        timeout=20,
-    )
-    response.raise_for_status()
-    response = response.json()['clientType']
+def get_day_details_traders_type_data(symbol_id: str, date: jdate, response: dict = None) -> dict:
+    if response is None:
+        t = date.togregorian().strftime('%Y%m%d')
+        response = safe_request(
+            method='GET',
+            url=f'http://cdn.tsetmc.com/api/ClientType/GetClientTypeHistory/{symbol_id}/{t}',
+            params={},
+            headers={
+                'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36',
+            },
+            verify=False
+        )
+        response = response.json()['clientType']
 
     return {
         'legal': {
@@ -181,19 +180,19 @@ def get_day_details_traders_type_data(symbol_id: str, date: jdate) -> dict:
     }
 
 
-def get_day_details_thresholds_data(symbol_id: str, date: jdate) -> dict:
-    t = date.togregorian().strftime('%Y%m%d')
-    response = requests.get(
-        url=f'http://cdn.tsetmc.com/api/MarketData/GetStaticThreshold/{symbol_id}/{t}',
-        params={},
-        headers={
-            'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36',
-        },
-        verify=False,
-        timeout=20,
-    )
-    response.raise_for_status()
-    response = response.json()['staticThreshold']
+def get_day_details_thresholds_data(symbol_id: str, date: jdate, response: dict = None) -> dict:
+    if response is None:
+        t = date.togregorian().strftime('%Y%m%d')
+        response = safe_request(
+            method='GET',
+            url=f'http://cdn.tsetmc.com/api/MarketData/GetStaticThreshold/{symbol_id}/{t}',
+            params={},
+            headers={
+                'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36',
+            },
+            verify=False
+        )
+        response = response.json()['staticThreshold']
 
     return {
         'max': response[1]['psGelStaMax'],
@@ -201,19 +200,19 @@ def get_day_details_thresholds_data(symbol_id: str, date: jdate) -> dict:
     }
 
 
-def get_day_details_shareholders_data(symbol_id: str, date: jdate) -> tuple[list[dict], list[dict]]:
+def get_day_details_shareholders_data(symbol_id: str, date: jdate, response: dict = None) -> tuple[list[dict], list[dict]]:
     t = date.togregorian().strftime('%Y%m%d')
-    response = requests.get(
-        url=f'http://cdn.tsetmc.com/api/Shareholder/{symbol_id}/{t}',
-        params={},
-        headers={
-            'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36',
-        },
-        verify=False,
-        timeout=20,
-    )
-    response.raise_for_status()
-    response = response.json()['shareShareholder']
+    if response is None:
+        response = safe_request(
+            method='GET',
+            url=f'http://cdn.tsetmc.com/api/Shareholder/{symbol_id}/{t}',
+            params={},
+            headers={
+                'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36',
+            },
+            verify=False
+        )
+        response = response.json()['shareShareholder']
 
     old_shareholders = []
     new_shareholders = []
@@ -234,18 +233,18 @@ def get_day_details_shareholders_data(symbol_id: str, date: jdate) -> tuple[list
     return old_shareholders, new_shareholders
 
 
-def get_shareholder_chart_data(symbol_id: str, shareholder_id: str, days: int) -> list[dict]:
-    response = requests.get(
-        url=f'http://cdn.tsetmc.com/api/Shareholder/GetShareHolderHistory/{symbol_id}/{shareholder_id}/{days}',
-        params={},
-        headers={
-            'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36',
-        },
-        verify=False,
-        timeout=20,
-    )
-    response.raise_for_status()
-    response = response.json()['shareHolder']
+def get_shareholder_chart_data(symbol_id: str, shareholder_id: str, days: int, response: dict = None) -> list[dict]:
+    if response is None:
+        response = safe_request(
+            method='GET',
+            url=f'http://cdn.tsetmc.com/api/Shareholder/GetShareHolderHistory/{symbol_id}/{shareholder_id}/{days}',
+            params={},
+            headers={
+                'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36',
+            },
+            verify=False
+        )
+        response = response.json()['shareHolder']
 
     return [{
         'date': convert_deven_to_jdate(deven=row['dEven']),
@@ -254,18 +253,18 @@ def get_shareholder_chart_data(symbol_id: str, shareholder_id: str, days: int) -
     } for row in response]
 
 
-def get_shareholder_portfolio(shareholder_id: str) -> list[dict]:
-    response = requests.get(
-        url=f'http://cdn.tsetmc.com/api/Shareholder/GetShareHolderCompanyList/{shareholder_id}',
-        params={},
-        headers={
-            'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36',
-        },
-        verify=False,
-        timeout=20,
-    )
-    response.raise_for_status()
-    response = response.json()['shareHolderShare']
+def get_shareholder_portfolio(shareholder_id: str, response: dict = None) -> list[dict]:
+    if response is None:
+        response = safe_request(
+            method='GET',
+            url=f'http://cdn.tsetmc.com/api/Shareholder/GetShareHolderCompanyList/{shareholder_id}',
+            params={},
+            headers={
+                'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36',
+            },
+            verify=False
+        )
+        response = response.json()['shareHolderShare']
 
     return [{
         'symbol_id': row['instrument']['insCode'],
@@ -274,3 +273,139 @@ def get_shareholder_portfolio(shareholder_id: str) -> list[dict]:
         'shares_count': row['numberOfShares'],
         'shares_percent': row['perOfShares'],
     } for row in response]
+
+
+async def aio_get_day_details_price_overview(symbol_id: str, date: jdate) -> dict:
+    t = date.togregorian().strftime('%Y%m%d')
+    response = await aio_safe_request(
+        method='GET',
+        url=f'http://cdn.tsetmc.com/api/ClosingPrice/GetClosingPriceDaily/{symbol_id}/{t}',
+        params={},
+        headers={
+            'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36',
+        },
+        verify=False
+    )
+    js = (await response.json())
+    print(js)
+    response = js['closingPriceDaily']
+    return get_day_details_price_overview(symbol_id=symbol_id, date=date, response=response)
+
+
+async def aio_get_day_details_price_data(symbol_id: str, date: jdate) -> list[dict]:
+    t = date.togregorian().strftime('%Y%m%d')
+    response = await aio_safe_request(
+        method='GET',
+        url=f'http://cdn.tsetmc.com/api/ClosingPrice/GetClosingPriceHistory/{symbol_id}/{t}',
+        params={},
+        headers={
+            'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36',
+        },
+        verify=False
+    )
+    response = (await response.json())['closingPriceHistory']
+    return get_day_details_price_data(symbol_id=symbol_id, date=date, response=response)
+
+
+async def aio_get_day_details_orderbook_data(symbol_id: str, date: jdate) -> list[dict]:
+    t = date.togregorian().strftime('%Y%m%d')
+    response = await aio_safe_request(
+        method='GET',
+        url=f'http://cdn.tsetmc.com/api/BestLimits/{symbol_id}/{t}',
+        params={},
+        headers={
+            'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36',
+        },
+        verify=False
+    )
+    response = (await response.json())['bestLimitsHistory']
+    return get_day_details_orderbook_data(symbol_id=symbol_id, date=date, response=response)
+
+
+async def aio_get_day_details_trade_data(symbol_id: str, date: jdate, summarize: bool) -> list[dict]:
+    t = date.togregorian().strftime('%Y%m%d')
+    summarize_url_ph = 'true' if summarize else 'false'
+    response = await aio_safe_request(
+        method='GET',
+        url=f'http://cdn.tsetmc.com/api/Trade/GetTradeHistory/{symbol_id}/{t}/{summarize_url_ph}',
+        params={},
+        headers={
+            'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36',
+        },
+        verify=False
+    )
+    response = (await response.json())['tradeHistory']
+    return get_day_details_trade_data(symbol_id=symbol_id, date=date, summarize=summarize, response=response)
+
+
+async def aio_get_day_details_traders_type_data(symbol_id: str, date: jdate) -> dict:
+    t = date.togregorian().strftime('%Y%m%d')
+    response = await aio_safe_request(
+        method='GET',
+        url=f'http://cdn.tsetmc.com/api/ClientType/GetClientTypeHistory/{symbol_id}/{t}',
+        params={},
+        headers={
+            'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36',
+        },
+        verify=False
+    )
+    response = (await response.json())['clientType']
+    return get_day_details_traders_type_data(symbol_id=symbol_id, date=date, response=response)
+
+
+async def aio_get_day_details_thresholds_data(symbol_id: str, date: jdate) -> dict:
+    t = date.togregorian().strftime('%Y%m%d')
+    response = await aio_safe_request(
+        method='GET',
+        url=f'http://cdn.tsetmc.com/api/MarketData/GetStaticThreshold/{symbol_id}/{t}',
+        params={},
+        headers={
+            'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36',
+        },
+        verify=False
+    )
+    response = (await response.json())['staticThreshold']
+    return get_day_details_thresholds_data(symbol_id=symbol_id, date=date, response=response)
+
+
+async def aio_get_day_details_shareholders_data(symbol_id: str, date: jdate) -> tuple[list[dict], list[dict]]:
+    t = date.togregorian().strftime('%Y%m%d')
+    response = await aio_safe_request(
+        method='GET',
+        url=f'http://cdn.tsetmc.com/api/Shareholder/{symbol_id}/{t}',
+        params={},
+        headers={
+            'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36',
+        },
+        verify=False
+    )
+    response = (await response.json())['shareShareholder']
+    return get_day_details_shareholders_data(symbol_id=symbol_id, date=date, response=response)
+
+
+async def aio_get_shareholder_chart_data(symbol_id: str, shareholder_id: str, days: int) -> list[dict]:
+    response = await aio_safe_request(
+        method='GET',
+        url=f'http://cdn.tsetmc.com/api/Shareholder/GetShareHolderHistory/{symbol_id}/{shareholder_id}/{days}',
+        params={},
+        headers={
+            'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36',
+        },
+        verify=False
+    )
+    response = (await response.json())['shareHolder']
+    return get_shareholder_chart_data(symbol_id=symbol_id, shareholder_id=shareholder_id, days=days, response=response)
+
+
+async def aio_get_shareholder_portfolio(shareholder_id: str) -> list[dict]:
+    response = await aio_safe_request(
+        method='GET',
+        url=f'http://cdn.tsetmc.com/api/Shareholder/GetShareHolderCompanyList/{shareholder_id}',
+        params={},
+        headers={
+            'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36',
+        },
+        verify=False
+    )
+    response = (await response.json())['shareHolderShare']
+    return get_shareholder_portfolio(shareholder_id=shareholder_id, response=response)

--- a/lib/tsetmc_api/day_details/day_details.py
+++ b/lib/tsetmc_api/day_details/day_details.py
@@ -13,14 +13,15 @@ class DayDetails:
     def __init__(self, symbol_id: str, date: jdate):
         self.symbol_id = symbol_id
         self.date = date
-
-    def get_price_overview(self) -> DayDetailsPriceOverview:
+    
+    def get_price_overview(self, raw_data: dict = None) -> DayDetailsPriceOverview:
         """
         returns an overview of price information for that day
         """
-
-        raw_data = _core.get_day_details_price_overview(symbol_id=self.symbol_id, date=self.date)
-
+        
+        if raw_data is None:
+            raw_data = _core.get_day_details_price_overview(symbol_id=self.symbol_id, date=self.date)
+        
         return DayDetailsPriceOverview(
             price_change=raw_data['price_change'],
             low=raw_data['low'],
@@ -33,14 +34,15 @@ class DayDetails:
             volume=raw_data['volume'],
             value=raw_data['value'],
         )
-
-    def get_price_data(self) -> list[DayDetailsPriceDataRow]:
+    
+    def get_price_data(self, raw_data: list[dict] = None) -> list[DayDetailsPriceDataRow]:
         """
         returns instant prices (for each time in that date)
         """
-
-        raw_data = _core.get_day_details_price_data(symbol_id=self.symbol_id, date=self.date)
-
+        
+        if raw_data is None:
+            raw_data = _core.get_day_details_price_data(symbol_id=self.symbol_id, date=self.date)
+        
         return [DayDetailsPriceDataRow(
             time=row['time'],
             close=row['close'],
@@ -49,14 +51,15 @@ class DayDetails:
             volume=row['volume'],
             count=row['count'],
         ) for row in raw_data]
-
-    def get_orderbook_data(self) -> list[DayDetailsOrderBookDataRow]:
+    
+    def get_orderbook_data(self, raw_data: list[dict] = None) -> list[DayDetailsOrderBookDataRow]:
         """
         returns instant orderbooks (for each time in that date)
         """
-
-        raw_data = _core.get_day_details_orderbook_data(symbol_id=self.symbol_id, date=self.date)
-
+        
+        if raw_data is None:
+            raw_data = _core.get_day_details_orderbook_data(symbol_id=self.symbol_id, date=self.date)
+        
         return [DayDetailsOrderBookDataRow(
             time=data['time'],
             buy_rows=[DayDetailsOrderBookRow(
@@ -72,14 +75,15 @@ class DayDetails:
                 volume=row['volume'],
             ) for row in data['sell_rows']],
         ) for data in raw_data]
-
-    def get_traders_type_data(self) -> DayDetailsTradersTypeData:
+    
+    def get_traders_type_data(self, raw_data: dict = None) -> DayDetailsTradersTypeData:
         """
         returns traders type information for that day
         """
-
-        raw_data = _core.get_day_details_traders_type_data(symbol_id=self.symbol_id, date=self.date)
-
+        
+        if raw_data is None:
+            raw_data = _core.get_day_details_traders_type_data(symbol_id=self.symbol_id, date=self.date)
+        
         return DayDetailsTradersTypeData(
             legal=DayDetailsTradersTypeInfo(
                 buy=DayDetailsTradersTypeSubInfo(
@@ -106,37 +110,42 @@ class DayDetails:
                 ),
             ),
         )
-
-    def get_trades_data(self, summarize: bool = False) -> list[DayDetailsTradeDataRow]:
+    
+    def get_trades_data(self, summarize: bool = False, raw_data: list[dict] = None) -> list[DayDetailsTradeDataRow]:
         """
         gets all trade data
         """
-
-        raw_data = _core.get_day_details_trade_data(symbol_id=self.symbol_id, date=self.date, summarize=summarize)
-
+        
+        if raw_data is None:
+            raw_data = _core.get_day_details_trade_data(symbol_id=self.symbol_id, date=self.date, summarize=summarize)
+        
         return [DayDetailsTradeDataRow(
             time=row['time'],
             price=row['price'],
             volume=row['volume'],
         ) for row in raw_data]
-
-    def get_thresholds_data(self) -> DayDetailsThresholdsData:
-        raw_data = _core.get_day_details_thresholds_data(symbol_id=self.symbol_id, date=self.date)
+    
+    def get_thresholds_data(self, raw_data: dict = None) -> DayDetailsThresholdsData:
+        if raw_data is None:
+            raw_data = _core.get_day_details_thresholds_data(symbol_id=self.symbol_id, date=self.date)
         return DayDetailsThresholdsData(
             range_max=raw_data['max'],
             range_min=raw_data['min'],
         )
-
-    def get_shareholders_data(self) -> tuple[list[DayDetailsShareHolderDataRow], list[DayDetailsShareHolderDataRow]]:
+    
+    def get_shareholders_data(self, raw_data: tuple[list[dict], list[dict]] = None) -> tuple[
+        list[DayDetailsShareHolderDataRow], list[DayDetailsShareHolderDataRow]]:
         """
         gets list of shareholders before and after the day
         """
-
-        raw_old_shareholders, raw_new_shareholders = _core.get_day_details_shareholders_data(
-            symbol_id=self.symbol_id,
-            date=self.date,
-        )
-
+        
+        if raw_data is None:
+            raw_data = _core.get_day_details_shareholders_data(
+                symbol_id=self.symbol_id,
+                date=self.date,
+            )
+        raw_old_shareholders, raw_new_shareholders = raw_data
+        
         old_shareholders = [DayDetailsShareHolderDataRow(
             symbol_id=self.symbol_id,
             date=self.date,
@@ -144,7 +153,7 @@ class DayDetails:
             count=row['count'],
             percentage=row['percentage'],
         ) for row in raw_old_shareholders]
-
+        
         new_shareholders = [DayDetailsShareHolderDataRow(
             symbol_id=self.symbol_id,
             date=self.date,
@@ -152,5 +161,41 @@ class DayDetails:
             shares_count=row['shares_count'],
             shares_percentage=row['shares_percentage'],
         ) for row in raw_new_shareholders]
-
+        
         return old_shareholders, new_shareholders
+    
+    async def aio_get_price_overview(self) -> DayDetailsPriceOverview:
+        return self.get_price_overview(
+            raw_data=await _core.aio_get_day_details_price_overview(symbol_id=self.symbol_id, date=self.date)
+        )
+    
+    async def aio_get_price_data(self) -> list[DayDetailsPriceDataRow]:
+        return self.get_price_data(
+            raw_data=await _core.aio_get_day_details_price_data(symbol_id=self.symbol_id, date=self.date)
+        )
+    
+    async def aio_get_orderbook_data(self) -> list[DayDetailsOrderBookDataRow]:
+        return self.get_orderbook_data(
+            raw_data=await _core.aio_get_day_details_orderbook_data(symbol_id=self.symbol_id, date=self.date)
+        )
+    
+    async def aio_get_traders_type_data(self) -> DayDetailsTradersTypeData:
+        return self.get_traders_type_data(
+            raw_data=await _core.aio_get_day_details_traders_type_data(symbol_id=self.symbol_id, date=self.date)
+        )
+    
+    async def aio_get_trades_data(self, summarize: bool = False) -> list[DayDetailsTradeDataRow]:
+        return self.get_trades_data(
+            summarize=summarize,
+            raw_data=await _core.aio_get_day_details_trade_data(symbol_id=self.symbol_id, date=self.date, summarize=summarize)
+        )
+    
+    async def aio_get_thresholds_data(self) -> DayDetailsThresholdsData:
+        return self.get_thresholds_data(
+            raw_data=await _core.aio_get_day_details_thresholds_data(symbol_id=self.symbol_id, date=self.date)
+        )
+    
+    async def aio_get_shareholders_data(self) -> tuple[list[DayDetailsShareHolderDataRow], list[DayDetailsShareHolderDataRow]]:
+        return self.get_shareholders_data(
+            raw_data=await _core.aio_get_day_details_shareholders_data(symbol_id=self.symbol_id, date=self.date)
+        )

--- a/lib/tsetmc_api/day_details/shareholder.py
+++ b/lib/tsetmc_api/day_details/shareholder.py
@@ -15,14 +15,15 @@ class DayDetailsShareHolderPortfolioRow(BaseModel):
 class DayDetailsShareHolder(BaseModel):
     id: str
     name: str
-
-    def get_portfolio_data(self) -> list[DayDetailsShareHolderPortfolioRow]:
+    
+    def get_portfolio_data(self, raw_data: list[dict] = None) -> list[DayDetailsShareHolderPortfolioRow]:
         """
         returns list of companies owned by this shareholder
         """
-
-        raw_data = _core.get_shareholder_portfolio(shareholder_id=self.id)
-
+        
+        if raw_data is None:
+            raw_data = _core.get_shareholder_portfolio(shareholder_id=self.id)
+        
         return [DayDetailsShareHolderPortfolioRow(
             symbol_id=row['symbol_id'],
             short_name=row['short_name'],
@@ -30,13 +31,18 @@ class DayDetailsShareHolder(BaseModel):
             shares_count=row['shares_count'],
             shares_percent=row['shares_percent'],
         ) for row in raw_data]
+    
+    async def aio_get_portfolio_data(self) -> list[DayDetailsShareHolderPortfolioRow]:
+        return self.get_portfolio_data(
+            raw_data=await _core.aio_get_shareholder_portfolio(shareholder_id=self.id)
+        )
 
 
 class DayDetailsShareHolderChartRow(BaseModel):
     date: jdate
     shares_count: int
     shares_percentage: float
-
+    
     class Config:
         arbitrary_types_allowed = True
 
@@ -47,23 +53,34 @@ class DayDetailsShareHolderDataRow(BaseModel):
     shareholder: DayDetailsShareHolder
     shares_count: int
     shares_percentage: float
-
-    def get_chart_data(self, days: int = 90) -> list[DayDetailsShareHolderChartRow]:
+    
+    def get_chart_data(self, days: int = 90, raw_data: list[dict] = None) -> list[DayDetailsShareHolderChartRow]:
         """
         returns list of changes to shareholders share count in history of this symbol
         """
-
-        raw_data = _core.get_shareholder_chart_data(
-            symbol_id=self.symbol_id,
-            shareholder_id=self.shareholder.id,
-            days=days,
-        )
-
+        
+        if raw_data is None:
+            raw_data = _core.get_shareholder_chart_data(
+                symbol_id=self.symbol_id,
+                shareholder_id=self.shareholder.id,
+                days=days,
+            )
+        
         return [DayDetailsShareHolderChartRow(
             date=row['date'],
             shares_count=row['shares_count'],
             shares_percentage=row['shares_percentage'],
         ) for row in raw_data]
-
+    
+    async def aio_get_chart_data(self, days: int = 90) -> list[DayDetailsShareHolderChartRow]:
+        return self.get_chart_data(
+            days=days,
+            raw_data=await _core.aio_get_shareholder_chart_data(
+                symbol_id=self.symbol_id,
+                shareholder_id=self.shareholder.id,
+                days=days,
+            )
+        )
+    
     class Config:
         arbitrary_types_allowed = True

--- a/lib/tsetmc_api/group/_core.py
+++ b/lib/tsetmc_api/group/_core.py
@@ -1,17 +1,32 @@
-import requests
+from ..utils import safe_request, aio_safe_request
 
 
-def get_group_static_data() -> list[dict]:
-    response = requests.get(
+def get_group_static_data(response: dict = None) -> list[dict]:
+    if response is None:
+        response = safe_request(
+            method='GET',
+            url='http://cdn.tsetmc.com/api/StaticData/GetStaticData',
+            params={},
+            headers={
+                'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36',
+            },
+            verify=False
+        )
+        response = response.json()['staticData']
+    
+    return response
+
+
+async def aio_get_group_static_data() -> list[dict]:
+    response = await aio_safe_request(
+        method='GET',
         url='http://cdn.tsetmc.com/api/StaticData/GetStaticData',
         params={},
         headers={
             'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36',
         },
-        verify=False,
-        timeout=20,
+        verify=False
     )
-    response.raise_for_status()
-    response = response.json()['staticData']
-
-    return response
+    response = (await response.json())['staticData']
+    
+    return get_group_static_data(response)

--- a/lib/tsetmc_api/group/group.py
+++ b/lib/tsetmc_api/group/group.py
@@ -20,12 +20,13 @@ class Group(BaseModel):
     type: GroupType
 
     @staticmethod
-    def get_all_groups() -> list[Group]:
+    def get_all_groups(raw_data: list[dict] = None) -> list[Group]:
         """
         returns list of symbol groups
         """
-
-        raw_data = _core.get_group_static_data()
+        
+        if raw_data is None:
+            raw_data = _core.get_group_static_data()
         return [Group(
             id=row['id'],
             code=row['code'],
@@ -33,3 +34,7 @@ class Group(BaseModel):
             description=row['description'],
             type=GroupType.PAPER if row['type'] == 'PaperType' else GroupType.INDUSTRIAL,
         ) for row in raw_data]
+    
+    @staticmethod
+    async def aio_get_all_groups() -> list[Group]:
+        return Group.get_all_groups(raw_data=await _core.aio_get_group_static_data())

--- a/lib/tsetmc_api/market_map/_core.py
+++ b/lib/tsetmc_api/market_map/_core.py
@@ -1,25 +1,25 @@
-import requests
+from ..utils import safe_request, aio_safe_request
 
 
-def get_market_map_data(map_type: int, heven: int = 0) -> tuple[dict[dict], int]:
-    response = requests.get(
-        url='http://cdn.tsetmc.com/api/ClosingPrice/GetMarketMap',
-        params={
-            'market': 0,
-            'size': 1920,
-            'sector': 0,
-            'typeSelected': map_type,
-            'hEven': heven,
-        },
-        headers={
-            'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36',
-        },
-        verify=False,
-        timeout=20,
-    )
-    response.raise_for_status()
-    response = response.json()
-
+def get_market_map_data(map_type: int, heven: int = 0, response: dict = None) -> tuple[dict[dict], int]:
+    if response is None:
+        response = safe_request(
+            method='GET',
+            url='http://cdn.tsetmc.com/api/ClosingPrice/GetMarketMap',
+            params={
+                'market': 0,
+                'size': 1920,
+                'sector': 0,
+                'typeSelected': map_type,
+                'hEven': heven,
+            },
+            headers={
+                'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36',
+            },
+            verify=False
+        )
+        response = response.json()
+    
     min_heven = 0
     watch_data = {}
     for row in response:
@@ -41,3 +41,23 @@ def get_market_map_data(map_type: int, heven: int = 0) -> tuple[dict[dict], int]
         }
 
     return watch_data, min_heven
+
+
+async def aio_get_market_map_data(map_type: int, heven: int = 0) -> tuple[dict[dict], int]:
+    response = await aio_safe_request(
+        method='GET',
+        url='http://cdn.tsetmc.com/api/ClosingPrice/GetMarketMap',
+        params={
+            'market': 0,
+            'size': 1920,
+            'sector': 0,
+            'typeSelected': map_type,
+            'hEven': heven,
+        },
+        headers={
+            'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36',
+        },
+        verify=False
+    )
+    response = await response.json()
+    return get_market_map_data(map_type=map_type, heven=heven, response=response)

--- a/lib/tsetmc_api/market_map/map.py
+++ b/lib/tsetmc_api/market_map/map.py
@@ -35,14 +35,16 @@ class MarketMap:
 
         self._last_map_data = {}
 
-    def get_market_map_data(self, map_type: MapType = MapType.MARKET_VALUE) -> dict[str, MapDataRow]:
+    def get_market_map_data(self, map_type: MapType = MapType.MARKET_VALUE, raw_data: tuple[dict[dict], int] = None) -> dict[str, MapDataRow]:
         """
         returns symbol data in market map (in "naghshe bazar" page)
         !!! webserver occasionally throws 403 error, you should retry in a few seconds when this happens
         """
-
-        raw_data, new_heven = _core.get_market_map_data(map_type=map_type.value, heven=self._heven)
-
+        
+        if raw_data is None:
+            raw_data = _core.get_market_map_data(map_type=map_type.value, heven=self._heven)
+        raw_data, new_heven = raw_data
+        
         self._last_map_data = deep_update(self._last_map_data, raw_data)
 
         map_data = {key: MapDataRow(
@@ -64,3 +66,10 @@ class MarketMap:
         ) for key, data in raw_data.items()}
 
         return map_data
+    
+    async def aio_get_market_map_data(self, map_type: MapType = MapType.MARKET_VALUE) -> dict[str, MapDataRow]:
+        return self.get_market_map_data(
+            map_type=map_type,
+            raw_data=await _core.aio_get_market_map_data(map_type=map_type.value, heven=self._heven)
+        )
+        

--- a/lib/tsetmc_api/market_watch/watch.py
+++ b/lib/tsetmc_api/market_watch/watch.py
@@ -12,22 +12,24 @@ class MarketWatch:
         self._refid = 0
         self._last_price_data = {}
 
-    def get_price_data(self) -> dict[str, WatchPriceDataRow]:
+    def get_price_data(self, raw_data: tuple[dict, int, int] = None) -> dict[str, WatchPriceDataRow]:
         """
         gets basic price information (in "didbane bazar" page)
         """
-
-        raw_data, new_refid, new_heven, = _core.get_watch_price_data(refid=self._refid, heven=self._heven)
-
+        
+        if raw_data is None:
+            raw_data = _core.get_watch_price_data(refid=self._refid, heven=self._heven)
+        raw_data, new_refid, new_heven, = raw_data
+        
         self._last_price_data = deep_update(self._last_price_data, raw_data)
-
+        
         watch_data = {}
         for symbol_id in self._last_price_data.keys():
             data = self._last_price_data[symbol_id]
-
+            
             if 'symbol_id' not in data:
                 continue
-
+            
             watch_data[symbol_id] = WatchPriceDataRow(
                 symbol_id=data['symbol_id'],
                 isin=data['isin'],
@@ -65,19 +67,20 @@ class MarketWatch:
                     ) for row in data['orderbook']['sell_rows'].values()],
                 )
             )
-
+        
         self._heven = new_heven
         self._refid = new_refid
-
+        
         return watch_data
-
-    def get_traders_type_data(self) -> dict[str, WatchTradersTypeDataRow]:
+    
+    def get_traders_type_data(self, raw_data: dict = None) -> dict[str, WatchTradersTypeDataRow]:
         """
         gets traders type data (in "didebane bazar" page)
         """
-
-        raw_data = _core.get_watch_traders_type_data()
-
+        
+        if raw_data is None:
+            raw_data = _core.get_watch_traders_type_data()
+        
         watch_data = {}
         for key, data in raw_data.items():
             watch_data[key] = WatchTradersTypeDataRow(
@@ -102,16 +105,17 @@ class MarketWatch:
                     ),
                 ),
             )
-
+        
         return watch_data
-
-    def get_daily_history_data(self) -> dict[str, list[WatchDailyHistoryDataRow]]:
+    
+    def get_daily_history_data(self, raw_data: dict = None) -> dict[str, list[WatchDailyHistoryDataRow]]:
         """
         gets 30 day history of symbols (in "didbane bazar" page)
         """
-
-        raw_data = _core.get_watch_daily_history_data()
-
+        
+        if raw_data is None:
+            raw_data = _core.get_watch_daily_history_data()
+        
         watch_data = {}
         for symbol_id in raw_data.keys():
             watch_data[symbol_id] = [WatchDailyHistoryDataRow(
@@ -126,17 +130,50 @@ class MarketWatch:
                 high=row['high'],
                 yesterday=row['yesterday'],
             ) for row in raw_data[symbol_id]]
-
+        
         return watch_data
-
-    def get_raw_stats_data(self) -> dict[list]:
+    
+    def get_raw_stats_data(self, raw_data: dict = None) -> dict[list]:
         """
         returns a list of stats for each symbol. refer to tsetmc.com for information of what each item in the list is
         """
-
-    def get_stats_data(self) -> dict[dict]:
+        
+        if raw_data is None:
+            raw_data = _core.get_watch_raw_stats_data()
+        
+        return raw_data
+    
+    def get_stats_data(self, raw_data: dict = None) -> dict[dict]:
         """
         !!! EXPERIMENTAL: returns stats in dict, may be wrong !!!
         """
-
-        return _core.get_watch_stats_data()
+        
+        if raw_data is None:
+            raw_data = _core.get_watch_stats_data()
+        
+        return raw_data
+    
+    async def aio_get_price_data(self) -> dict[str, WatchPriceDataRow]:
+        return self.get_price_data(
+            raw_data=await _core.aio_get_watch_price_data(refid=self._refid, heven=self._heven)
+        )
+    
+    async def aio_get_traders_type_data(self) -> dict[str, WatchTradersTypeDataRow]:
+        return self.get_traders_type_data(
+            raw_data=await _core.aio_get_watch_traders_type_data()
+        )
+    
+    async def aio_get_daily_history_data(self) -> dict[str, list[WatchDailyHistoryDataRow]]:
+        return self.get_daily_history_data(
+            raw_data=await _core.aio_get_watch_daily_history_data()
+        )
+    
+    async def aio_get_raw_stats_data(self) -> dict[list]:
+        return self.get_raw_stats_data(
+            raw_data=await _core.aio_get_watch_raw_stats_data()
+        )
+    
+    async def aio_get_stats_data(self) -> dict[dict]:
+        return self.get_stats_data(
+            raw_data=await _core.aio_get_watch_stats_data()
+        )

--- a/lib/tsetmc_api/symbol/_core.py
+++ b/lib/tsetmc_api/symbol/_core.py
@@ -1,23 +1,22 @@
 import ast
 import locale
 
-import requests
 from bs4 import BeautifulSoup
 from jdatetime import time as jtime, date as jdate, datetime as jdatetime
 
-from ..utils import convert_deven_to_jdate
+from ..utils import convert_deven_to_jdate, safe_request, aio_safe_request
 
 
-def get_symbol_intraday_price_chart(symbol_id: str) -> list[dict]:
-    response = requests.get(
-        url='http://old.tsetmc.com/tsev2/chart/data/IntraDayPrice.aspx',
-        params={'i': symbol_id},
-        verify=False,
-        timeout=20,
-    )
-    response.raise_for_status()
-    response = response.text
-
+def get_symbol_intraday_price_chart(symbol_id: str, response: str = None) -> list[dict]:
+    if response is None:
+        response = safe_request(
+            method='GET',
+            url='http://old.tsetmc.com/tsev2/chart/data/IntraDayPrice.aspx',
+            params={'i': symbol_id},
+            verify=False
+        )
+        response = response.text
+    
     ticks = response.split(';')
 
     result = []
@@ -36,19 +35,19 @@ def get_symbol_intraday_price_chart(symbol_id: str) -> list[dict]:
     return result
 
 
-def get_symbol_price_overview(symbol_id: str) -> dict:
-    response = requests.get(
-        url='http://old.tsetmc.com/tsev2/data/instinfodata.aspx',
-        params={
-            'i': symbol_id,
-            'c': 27,
-        },
-        verify=False,
-        timeout=20,
-    )
-    response.raise_for_status()
-    response = response.text
-
+def get_symbol_price_overview(symbol_id: str, response: str = None) -> dict:
+    if response is None:
+        response = safe_request(
+            method='GET',
+            url='http://old.tsetmc.com/tsev2/data/instinfodata.aspx',
+            params={
+                'i': symbol_id,
+                'c': 27,
+            },
+            verify=False
+        )
+        response = response.text
+    
     all_sections = response.split(';')
 
     # price section
@@ -144,19 +143,19 @@ def get_symbol_price_overview(symbol_id: str) -> dict:
     }
 
 
-def get_symbol_supervisor_messages(symbol_id: str) -> list[dict]:
-    response = requests.get(
-        url='http://old.tsetmc.com/Loader.aspx',
-        params={
-            'i': symbol_id,
-            'Partree': '15131W',
-        },
-        verify=False,
-        timeout=20,
-    )
-    response.raise_for_status()
-    response = response.text
-
+def get_symbol_supervisor_messages(symbol_id: str, response: str = None) -> list[dict]:
+    if response is None:
+        response = safe_request(
+            method='GET',
+            url='http://old.tsetmc.com/Loader.aspx',
+            params={
+                'i': symbol_id,
+                'Partree': '15131W',
+            },
+            verify=False
+        )
+        response = response.text
+    
     soup = BeautifulSoup(response, 'lxml')
 
     trs = soup.find('div', {'class': 'content'}).table.tbody.find_all('tr')
@@ -179,20 +178,20 @@ def get_symbol_supervisor_messages(symbol_id: str) -> list[dict]:
     return messages
 
 
-def get_symbol_daily_ticks_history(symbol_id: str) -> list[dict]:
-    response = requests.get(
-        url='http://old.tsetmc.com/tsev2/data/InstTradeHistory.aspx',
-        params={
-            'i': symbol_id,
-            'Top': 999999,
-            'A': 0,
-        },
-        verify=False,
-        timeout=20,
-    )
-    response.raise_for_status()
-    response = response.text
-
+def get_symbol_daily_ticks_history(symbol_id: str, response: str = None) -> list[dict]:
+    if response is None:
+        response = safe_request(
+            method='GET',
+            url='http://old.tsetmc.com/tsev2/data/InstTradeHistory.aspx',
+            params={
+                'i': symbol_id,
+                'Top': 999999,
+                'A': 0,
+            },
+            verify=False
+        )
+        response = response.text
+    
     data = response.split(';')
     ticks = []
     for row in data:
@@ -220,18 +219,18 @@ def get_symbol_daily_ticks_history(symbol_id: str) -> list[dict]:
     return ticks
 
 
-def get_symbol_notifications(symbol_id: str) -> list[dict]:
-    response = requests.get(
-        url='http://old.tsetmc.com/tsev2/data/CodalTopNew.aspx',
-        params={
-            'i': symbol_id,
-        },
-        verify=False,
-        timeout=20,
-    )
-    response.raise_for_status()
-    response = response.text
-
+def get_symbol_notifications(symbol_id: str, response: str = None) -> list[dict]:
+    if response is None:
+        response = safe_request(
+            method='GET',
+            url='http://old.tsetmc.com/tsev2/data/CodalTopNew.aspx',
+            params={
+                'i': symbol_id,
+            },
+            verify=False
+        )
+        response = response.text
+    
     data = ast.literal_eval(response)
 
     notifications = [{
@@ -242,19 +241,19 @@ def get_symbol_notifications(symbol_id: str) -> list[dict]:
     return notifications
 
 
-def get_symbol_state_changes(symbol_id: str) -> list[dict]:
-    response = requests.get(
-        url='http://old.tsetmc.com/Loader.aspx',
-        params={
-            'i': symbol_id,
-            'Partree': '15131L',
-        },
-        verify=False,
-        timeout=20,
-    )
-    response.raise_for_status()
-    response = response.text
-
+def get_symbol_state_changes(symbol_id: str, response: str = None) -> list[dict]:
+    if response is None:
+        response = safe_request(
+            method='GET',
+            url='http://old.tsetmc.com/Loader.aspx',
+            params={
+                'i': symbol_id,
+                'Partree': '15131L',
+            },
+            verify=False
+        )
+        response = response.text
+    
     data = BeautifulSoup(response, 'lxml')
 
     state_changes = []
@@ -269,19 +268,19 @@ def get_symbol_state_changes(symbol_id: str) -> list[dict]:
     return state_changes
 
 
-def get_symbol_id_details(symbol_id: str) -> dict:
-    response = requests.get(
-        url='http://old.tsetmc.com/Loader.aspx',
-        params={
-            'i': symbol_id,
-            'Partree': '15131M',
-        },
-        verify=False,
-        timeout=20,
-    )
-    response.raise_for_status()
-    response = response.text
-
+def get_symbol_id_details(symbol_id: str, response: str = None) -> dict:
+    if response is None:
+        response = safe_request(
+            method='GET',
+            url='http://old.tsetmc.com/Loader.aspx',
+            params={
+                'i': symbol_id,
+                'Partree': '15131M',
+            },
+            verify=False
+        )
+        response = response.text
+    
     data = BeautifulSoup(response, 'lxml')
 
     trs = data.find_all('tr')
@@ -314,27 +313,30 @@ def get_symbol_id_details(symbol_id: str) -> dict:
     return result
 
 
-def get_symbol_traders_type_history(symbol_id: str) -> list[dict]:
-    response = requests.get(
-        url='http://old.tsetmc.com/tsev2/data/clienttype.aspx',
-        params={
-            'i': symbol_id,
-        },
-        verify=False,
-        timeout=20,
-    )
-    response.raise_for_status()
-    response = response.text
-
+def get_symbol_traders_type_history(symbol_id: str, response: str = None) -> list[dict]:
+    if response is None:
+        response = safe_request(
+            method='GET',
+            url='http://old.tsetmc.com/tsev2/data/clienttype.aspx',
+            params={
+                'i': symbol_id,
+            },
+            verify=False
+        )
+        response = response.text
+    
     traders_type_history = []
     raw_data = response.split(';')
     for row in raw_data:
-        (
-            dt,
-            r_buy_c, l_buy_c, r_sell_c, l_sell_c,
-            r_buy_v, l_buy_v, r_sell_v, l_sell_v,
-            r_buy_vl, l_buy_vl, r_sell_vl, l_sell_vl
-        ) = row.split(',')
+        try:
+            (
+                dt,
+                r_buy_c, l_buy_c, r_sell_c, l_sell_c,
+                r_buy_v, l_buy_v, r_sell_v, l_sell_v,
+                r_buy_vl, l_buy_vl, r_sell_vl, l_sell_vl
+            ) = row.split(',')
+        except ValueError:
+            continue
         traders_type_history.append({
             'date': jdate.fromgregorian(
                 year=int(dt[:4]),
@@ -370,19 +372,19 @@ def get_symbol_traders_type_history(symbol_id: str) -> list[dict]:
     return traders_type_history
 
 
-def get_symbol_shareholders(company_isin: str) -> list[dict]:
-    response = requests.get(
-        url='http://old.tsetmc.com/Loader.aspx',
-        params={
-            'c': company_isin,
-            'Partree': '15131T',
-        },
-        verify=False,
-        timeout=20,
-    )
-    response.raise_for_status()
-    response = response.text
-
+def get_symbol_shareholders(company_isin: str, response: str = None) -> list[dict]:
+    if response is None:
+        response = safe_request(
+            method='GET',
+            url='http://old.tsetmc.com/Loader.aspx',
+            params={
+                'c': company_isin,
+                'Partree': '15131T',
+            },
+            verify=False
+        )
+        response = response.text
+    
     soup = BeautifulSoup(response, 'lxml')
 
     shareholders = []
@@ -395,7 +397,7 @@ def get_symbol_shareholders(company_isin: str) -> list[dict]:
         name = tds[0].text.strip()
         count = int(tds[1].div['title'].replace(',', ''))
         percentage = float(tds[2].text)
-        change = locale.atoi(tds[3].text.strip())
+        change = locale.atoi(tds[3].text.strip().replace(',', ''))
 
         shareholders.append({
             'id': shareholder_id,
@@ -408,18 +410,18 @@ def get_symbol_shareholders(company_isin: str) -> list[dict]:
     return shareholders
 
 
-def get_symbol_shareholder_details(shareholder_id: str, company_isin: str):
-    response = requests.get(
-        url=f'http://old.tsetmc.com/tsev2/data/ShareHolder.aspx?i={shareholder_id}%2C{company_isin}',
-        params={
-            'i': f'{shareholder_id}%C{company_isin}',
-        },
-        verify=False,
-        timeout=20,
-    )
-    response.raise_for_status()
-    response = response.text
-
+def get_symbol_shareholder_details(shareholder_id: str, company_isin: str, response: str = None) -> dict:
+    if response is None:
+        response = safe_request(
+            method='GET',
+            url=f'http://old.tsetmc.com/tsev2/data/ShareHolder.aspx?i={shareholder_id}%2C{company_isin}',
+            params={
+                'i': f'{shareholder_id}%C{company_isin}',
+            },
+            verify=False
+        )
+        response = response.text
+    
     response = response.split(';')
 
     chart = []
@@ -443,3 +445,138 @@ def get_symbol_shareholder_details(shareholder_id: str, company_isin: str):
         'chart': chart,
         'portfolio': portfolio,
     }
+
+
+async def aio_get_symbol_intraday_price_chart(symbol_id: str) -> list[dict]:
+    response = await aio_safe_request(
+        method='GET',
+        url='http://old.tsetmc.com/tsev2/chart/data/IntraDayPrice.aspx',
+        params={'i': symbol_id},
+        verify=False
+    )
+    response = response.text
+    return get_symbol_intraday_price_chart(symbol_id=symbol_id, response=response)
+
+
+async def aio_get_symbol_price_overview(symbol_id: str) -> dict:
+    response = await aio_safe_request(
+        method='GET',
+        url='http://old.tsetmc.com/tsev2/data/instinfodata.aspx',
+        params={
+            'i': symbol_id,
+            'c': 27,
+        },
+        verify=False
+    )
+    response = response.text
+    return get_symbol_price_overview(symbol_id=symbol_id, response=response)
+
+
+async def aio_get_symbol_supervisor_messages(symbol_id: str) -> list[dict]:
+    response = await aio_safe_request(
+        method='GET',
+        url='http://old.tsetmc.com/Loader.aspx',
+        params={
+            'i': symbol_id,
+            'Partree': '15131W',
+        },
+        verify=False
+    )
+    response = response.text
+    return get_symbol_supervisor_messages(symbol_id=symbol_id, response=response)
+
+
+async def aio_get_symbol_daily_ticks_history(symbol_id: str) -> list[dict]:
+    response = await aio_safe_request(
+        method='GET',
+        url='http://old.tsetmc.com/tsev2/data/InstTradeHistory.aspx',
+        params={
+            'i': symbol_id,
+            'Top': 999999,
+            'A': 0,
+        },
+        verify=False
+    )
+    response = response.text
+    return get_symbol_daily_ticks_history(symbol_id=symbol_id, response=response)
+
+
+async def aio_get_symbol_notifications(symbol_id: str) -> list[dict]:
+    response = await aio_safe_request(
+        method='GET',
+        url='http://old.tsetmc.com/tsev2/data/CodalTopNew.aspx',
+        params={
+            'i': symbol_id,
+        },
+        verify=False
+    )
+    response = response.text
+    return get_symbol_notifications(symbol_id=symbol_id, response=response)
+
+
+async def aio_get_symbol_state_changes(symbol_id: str) -> list[dict]:
+    response = await aio_safe_request(
+        method='GET',
+        url='http://old.tsetmc.com/Loader.aspx',
+        params={
+            'i': symbol_id,
+            'Partree': '15131L',
+        },
+        verify=False
+    )
+    response = response.text
+    return get_symbol_state_changes(symbol_id=symbol_id, response=response)
+
+
+async def aio_get_symbol_id_details(symbol_id: str) -> dict:
+    response = await aio_safe_request(
+        method='GET',
+        url='http://old.tsetmc.com/Loader.aspx',
+        params={
+            'i': symbol_id,
+            'Partree': '15131M',
+        },
+        verify=False
+    )
+    response = response.text
+    return get_symbol_id_details(symbol_id=symbol_id, response=response)
+
+
+async def aio_get_symbol_traders_type_history(symbol_id: str) -> list[dict]:
+    response = await aio_safe_request(
+        method='GET',
+        url='http://old.tsetmc.com/tsev2/data/clienttype.aspx',
+        params={
+            'i': symbol_id,
+        },
+        verify=False
+    )
+    response = response.text
+    return get_symbol_traders_type_history(symbol_id=symbol_id, response=response)
+
+
+async def aio_get_symbol_shareholders(company_isin: str) -> list[dict]:
+    response = await aio_safe_request(
+        method='GET',
+        url='http://old.tsetmc.com/Loader.aspx',
+        params={
+            'c': company_isin,
+            'Partree': '15131T',
+        },
+        verify=False
+    )
+    response = response.text
+    return get_symbol_shareholders(company_isin=company_isin, response=response)
+
+
+async def aio_get_symbol_shareholder_details(shareholder_id: str, company_isin: str) -> dict:
+    response = await aio_safe_request(
+        method='GET',
+        url=f'http://old.tsetmc.com/tsev2/data/ShareHolder.aspx?i={shareholder_id}%2C{company_isin}',
+        params={
+            'i': f'{shareholder_id}%C{company_isin}',
+        },
+        verify=False
+    )
+    response = response.text
+    return get_symbol_shareholder_details(shareholder_id=shareholder_id, company_isin=company_isin, response=response)

--- a/lib/tsetmc_api/symbol/shareholder.py
+++ b/lib/tsetmc_api/symbol/shareholder.py
@@ -22,22 +22,31 @@ class SymbolShareHolder(BaseModel):
         super().__init__(**data)
         self._company_isin = _company_isin
 
-    def get_portfolio_data(self) -> list[SymbolShareHolderPortfolioRow]:
+    def get_portfolio_data(self, raw_data: dict = None) -> list[SymbolShareHolderPortfolioRow]:
         """
         returns list of companies owned by this shareholder
         """
-
-        raw_data = _core.get_symbol_shareholder_details(
-            shareholder_id=self.id,
-            company_isin=self._company_isin,
-        )['portfolio']
-
+        if raw_data is None:
+            raw_data = _core.get_symbol_shareholder_details(
+                shareholder_id=self.id,
+                company_isin=self._company_isin,
+            )
+        raw_data = raw_data['portfolio']
+        
         return [SymbolShareHolderPortfolioRow(
             symbol_id=row['symbol_id'],
             long_name=row['long_name'],
             shares_count=row['shares_count'],
             shares_percentage=row['shares_percentage'],
         ) for row in raw_data]
+    
+    async def aio_get_portfolio_data(self) -> list[SymbolShareHolderPortfolioRow]:
+        return self.get_portfolio_data(
+            raw_data=await _core.aio_get_symbol_shareholder_details(
+                shareholder_id=self.id,
+                company_isin=self._company_isin,
+            )
+        )
 
 
 class SymbolShareHolderChartRow(BaseModel):
@@ -53,18 +62,28 @@ class SymbolShareHolderDataRow(BaseModel):
     shares_count: int
     shares_percentage: float
     shares_change: int
-
-    def get_chart_data(self) -> list[SymbolShareHolderChartRow]:
+    
+    def get_chart_data(self, raw_data: dict = None) -> list[SymbolShareHolderChartRow]:
         """
         returns list of changes to shareholders share count in history of this symbol
         """
-
-        raw_data = _core.get_symbol_shareholder_details(
-            shareholder_id=self.shareholder.id,
-            company_isin=self.shareholder._company_isin,
-        )['chart']
-
+        
+        if raw_data is None:
+            raw_data = _core.get_symbol_shareholder_details(
+                shareholder_id=self.shareholder.id,
+                company_isin=self.shareholder._company_isin,
+            )
+        raw_data = raw_data['chart']
+        
         return [SymbolShareHolderChartRow(
             date=row['date'],
             shares_count=row['shares_count'],
         ) for row in raw_data]
+    
+    async def aio_get_chart_data(self) -> list[SymbolShareHolderChartRow]:
+        return self.get_chart_data(
+            raw_data=await _core.aio_get_symbol_shareholder_details(
+                shareholder_id=self.shareholder.id,
+                company_isin=self.shareholder._company_isin,
+            )
+        )

--- a/lib/tsetmc_api/symbol/symbol.py
+++ b/lib/tsetmc_api/symbol/symbol.py
@@ -13,14 +13,16 @@ from .traders_type import SymbolTradersTypeDataRow, SymbolTradersTypeInfo, Symbo
 class Symbol:
     def __init__(self, symbol_id: str):
         self.symbol_id = symbol_id
+        self._company_isin = None
 
-    def get_price_overview(self) -> SymbolPriceOverview:
+    def get_price_overview(self, raw_data: dict = None) -> SymbolPriceOverview:
         """
         gets the last price overview of the symbol and returns most of the information (in "dar yek negah" tab)
         """
-
-        raw_data = _core.get_symbol_price_overview(symbol_id=self.symbol_id)
-
+        
+        if raw_data is None:
+            raw_data = _core.get_symbol_price_overview(symbol_id=self.symbol_id)
+        
         tick = SymbolPriceData(
             last=raw_data['price_data']['last'],
             close=raw_data['price_data']['close'],
@@ -91,12 +93,13 @@ class Symbol:
             group_data=group_data,
         )
 
-    def get_intraday_price_chart_data(self) -> list[SymbolIntraDayPriceChartDataRow]:
+    def get_intraday_price_chart_data(self, raw_data: list[dict] = None) -> list[SymbolIntraDayPriceChartDataRow]:
         """
         gets last days intraday price chart (in "dar yek negah" tab)
         """
 
-        raw_data = _core.get_symbol_intraday_price_chart(symbol_id=self.symbol_id)
+        if raw_data is None:
+            raw_data = _core.get_symbol_intraday_price_chart(symbol_id=self.symbol_id)
 
         ticks = [SymbolIntraDayPriceChartDataRow(
             time=row['time'],
@@ -109,12 +112,13 @@ class Symbol:
 
         return ticks
 
-    def get_supervisor_messages_data(self) -> list[SymbolSupervisorMessageDataRow]:
+    def get_supervisor_messages_data(self, raw_data: list[dict] = None) -> list[SymbolSupervisorMessageDataRow]:
         """
         get list of supervisor messages (in "payame nazer" tab)
         """
 
-        raw_data = _core.get_symbol_supervisor_messages(symbol_id=self.symbol_id)
+        if raw_data is None:
+            raw_data = _core.get_symbol_supervisor_messages(symbol_id=self.symbol_id)
 
         messages = [SymbolSupervisorMessageDataRow(
             datetime=row['datetime'],
@@ -124,12 +128,13 @@ class Symbol:
 
         return messages
 
-    def get_notifications_data(self) -> list[SymbolNotificationsDataRow]:
+    def get_notifications_data(self, raw_data: list[dict] = None) -> list[SymbolNotificationsDataRow]:
         """
         get list of notifications (in "etelaiye ha" tab)
         """
 
-        raw_data = _core.get_symbol_notifications(symbol_id=self.symbol_id)
+        if raw_data is None:
+            raw_data = _core.get_symbol_notifications(symbol_id=self.symbol_id)
 
         notifications = [SymbolNotificationsDataRow(
             datetime=row['datetime'],
@@ -138,12 +143,13 @@ class Symbol:
 
         return notifications
 
-    def get_state_changes_data(self) -> list[SymbolStateChangeDataRow]:
+    def get_state_changes_data(self, raw_data: list[dict] = None) -> list[SymbolStateChangeDataRow]:
         """
         get list of state changes (in "taghire vaziat" tab)
         """
 
-        raw_data = _core.get_symbol_state_changes(symbol_id=self.symbol_id)
+        if raw_data is None:
+            raw_data = _core.get_symbol_state_changes(symbol_id=self.symbol_id)
 
         state_changes = [SymbolStateChangeDataRow(
             datetime=row['datetime'],
@@ -152,12 +158,13 @@ class Symbol:
 
         return state_changes
 
-    def get_daily_history(self) -> list[SymbolDailyPriceDataRow]:
+    def get_daily_history(self, raw_data: list[dict] = None) -> list[SymbolDailyPriceDataRow]:
         """
         get list of daily ticks history (in "sabeghe" tab)
         """
 
-        raw_data = _core.get_symbol_daily_ticks_history(symbol_id=self.symbol_id)
+        if raw_data is None:
+            raw_data = _core.get_symbol_daily_ticks_history(symbol_id=self.symbol_id)
 
         ticks = [SymbolDailyPriceDataRow(
             date=row['date'],
@@ -174,13 +181,16 @@ class Symbol:
 
         return ticks
 
-    def get_id_details(self) -> SymbolIdDetails:
+    def get_id_details(self, raw_data: dict = None) -> SymbolIdDetails:
         """
         gets symbol identity details and returns all the information (in "shenase" tab)
         """
 
-        raw_data = _core.get_symbol_id_details(symbol_id=self.symbol_id)
-
+        if raw_data is None:
+            raw_data = _core.get_symbol_id_details(symbol_id=self.symbol_id)
+        if self._company_isin is None:
+            self._company_isin = raw_data['company_isin']
+        
         details = SymbolIdDetails(
             isin=raw_data['isin'],
             short_isin=raw_data['short_isin'],
@@ -204,12 +214,13 @@ class Symbol:
 
         return details
 
-    def get_traders_type_history(self) -> list[SymbolTradersTypeDataRow]:
+    def get_traders_type_history(self, raw_data: list[dict] = None) -> list[SymbolTradersTypeDataRow]:
         """
         returns daily traders type history (in "haghihi-hoghooghi" tab)
         """
-
-        raw_data = _core.get_symbol_traders_type_history(symbol_id=self.symbol_id)
+        
+        if raw_data is None:
+            raw_data = _core.get_symbol_traders_type_history(symbol_id=self.symbol_id)
 
         traders_type_history = [SymbolTradersTypeDataRow(
             legal=SymbolTradersTypeInfo(
@@ -240,17 +251,20 @@ class Symbol:
 
         return traders_type_history
 
-    def get_shareholders_data(self) -> list[SymbolShareHolderDataRow]:
+    def get_shareholders_data(self, raw_data: list[dict] = None) -> list[SymbolShareHolderDataRow]:
         """
         returns list of major shareholders (in "saham daran" tab)
         """
-
-        company_isin = self.get_id_details().company_isin
-        raw_data = _core.get_symbol_shareholders(company_isin=company_isin)
-
+        if raw_data is None:
+            if self._company_isin is None:
+                self.get_id_details()
+            raw_data = _core.get_symbol_shareholders(company_isin=self._company_isin)
+        else:
+            raw_data = raw_data
+        
         shareholders = [SymbolShareHolderDataRow(
             shareholder=SymbolShareHolder(
-                _company_isin=company_isin,
+                _company_isin=self._company_isin,
                 id=row['id'],
                 name=row['name'],
             ),
@@ -258,5 +272,53 @@ class Symbol:
             shares_percentage=row['shares_percentage'],
             shares_change=row['shares_change'],
         ) for row in raw_data]
-
+        
         return shareholders
+    
+    async def aio_get_price_overview(self) -> SymbolPriceOverview:
+        return self.get_price_overview(
+            raw_data=await _core.aio_get_symbol_price_overview(symbol_id=self.symbol_id)
+        )
+    
+    async def aio_get_intraday_price_chart_data(self) -> list[SymbolIntraDayPriceChartDataRow]:
+        return self.get_intraday_price_chart_data(
+            raw_data=await _core.aio_get_symbol_intraday_price_chart(symbol_id=self.symbol_id)
+        )
+    
+    async def aio_get_supervisor_messages_data(self) -> list[SymbolSupervisorMessageDataRow]:
+        return self.get_supervisor_messages_data(
+            raw_data=await _core.aio_get_symbol_supervisor_messages(symbol_id=self.symbol_id)
+        )
+    
+    async def aio_get_notifications_data(self) -> list[SymbolNotificationsDataRow]:
+        return self.get_notifications_data(
+            raw_data=await _core.aio_get_symbol_notifications(symbol_id=self.symbol_id)
+        )
+    
+    async def aio_get_state_changes_data(self) -> list[SymbolStateChangeDataRow]:
+        return self.get_state_changes_data(
+            raw_data=await _core.aio_get_symbol_state_changes(symbol_id=self.symbol_id)
+        )
+    
+    async def aio_get_daily_history(self) -> list[SymbolDailyPriceDataRow]:
+        return self.get_daily_history(
+            raw_data=await _core.aio_get_symbol_daily_ticks_history(symbol_id=self.symbol_id)
+        )
+    
+    async def aio_get_id_details(self) -> SymbolIdDetails:
+        return self.get_id_details(
+            raw_data=await _core.aio_get_symbol_id_details(symbol_id=self.symbol_id)
+        )
+    
+    async def aio_get_traders_type_history(self) -> list[SymbolTradersTypeDataRow]:
+        return self.get_traders_type_history(
+            raw_data=await _core.aio_get_symbol_traders_type_history(symbol_id=self.symbol_id)
+        )
+    
+    async def aio_get_shareholders_data(self) -> list[SymbolShareHolderDataRow]:
+        if self._company_isin is None:
+            await self.aio_get_id_details()
+        
+        return self.get_shareholders_data(
+            raw_data=await _core.aio_get_symbol_shareholders(company_isin=self._company_isin)
+        )

--- a/lib/tsetmc_api/utils.py
+++ b/lib/tsetmc_api/utils.py
@@ -1,6 +1,59 @@
+from aiohttp import ClientSession
 from copy import deepcopy
-
 from jdatetime import date as jdate, time as jtime
+from requests import request
+from requests.exceptions import HTTPError
+
+
+def safe_request(method, url, timeout=20, **kwargs):
+    res = request(method.upper(), url, timeout=timeout, **kwargs)
+    res.raise_for_status()
+    return res
+
+
+async def aio_safe_request(method, url, timeout=20, **kwargs):
+    if 'verify' in kwargs:
+        kwargs['ssl'] = kwargs.pop('verify')
+    else:
+        kwargs.setdefault('ssl', True)
+    
+    async with ClientSession() as session:
+        # noinspection PyProtectedMember
+        response = await session._request(method.upper(), url, timeout=timeout, **kwargs)
+        response.text = await response.text()
+        response.close()
+    
+    response.status_code = response.status
+    
+    # region raise_for_status()
+    http_error_msg = ""
+    if isinstance(response.reason, bytes):
+        # We attempt to decode utf-8 first because some servers
+        # choose to localize their reason strings. If the string
+        # isn't utf-8, we fall back to iso-8859-1 for all other
+        # encodings. (See PR #3538)
+        try:
+            reason = response.reason.decode("utf-8")
+        except UnicodeDecodeError:
+            reason = response.reason.decode("iso-8859-1")
+    else:
+        reason = response.reason
+    
+    if 400 <= response.status_code < 500:
+        http_error_msg = (
+            f"{response.status_code} Client Error: {reason} for url: {response.url}"
+        )
+    
+    elif 500 <= response.status_code < 600:
+        http_error_msg = (
+            f"{response.status_code} Server Error: {reason} for url: {response.url}"
+        )
+    
+    if http_error_msg:
+        raise HTTPError(http_error_msg, response=response)
+    # endregion
+    
+    return response
 
 
 def deep_update(d1: dict, d2: dict) -> dict:

--- a/lib/tsetmc_api/utils.py
+++ b/lib/tsetmc_api/utils.py
@@ -1,5 +1,6 @@
-from aiohttp import ClientSession
 from copy import deepcopy
+
+from aiohttp import ClientSession
 from jdatetime import date as jdate, time as jtime
 from requests import request
 from requests.exceptions import HTTPError

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ python-dateutil = "^2.8.2"
 jdatetime = "^4.1.0"
 schedule = "^1.1.0"
 pydantic = "^1.10.2"
+aiohttp = "^3.8.3"
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
hi there
thanks for the great work on incomprehensible outputs on tsetmc APIs!
just changed a few things and hope it will be useful

#Major Changes:
added async requests `aiohttp>=3.8.3`
added `safe_request()` and `aio_safe_request()` to be able to intercept all requests
Note that the added functions for supporting async are just async wrappers for the base functions so if you want to change a logic in the future you just need to change the main functions and not the async ones

#Some Improvements:
change `http://members.tsetmc.com` to `https://members.tsetmc.com` because http is force redirected on this subdomain
added `_company_isin` to `symbol.Symbol()` to avoid two requests when running `get_shareholders_data()`
filled the body of `market_watch.MarketWatch().get_raw_stats_data()` function (I don't really know why it was empty)
better examples

#Some Bug-Fixes:
error-handling on `symbol._core.get_symbol_traders_type_history()` (sometimes the response is an empty string and causes an exception (this way it will return an empty list instead of throwing an exception))
added `replace(',', '')` to `change` variable in `symbol._core.get_symbol_shareholders()`

#Note:
please be informed that `aiohttp>=3.8.3` library has been added to project

and also a question:
in my tests i noticed that `old_shareholders` of `day_details.DayDetails().get_shareholders_data()` is always empty any idea why?